### PR TITLE
Add custom region and profiles

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -103,6 +103,7 @@ Here is the list of parameters that must be maintained in the ```config.properti
   - ```OKTA_PASSWORD``` is the password to use. If present will skip password input.
   - ```OKTA_BROWSER_AUTH``` set to **true** to use integrated web browser for authentication (default: **false**)
   - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse (default: get AWS profile name based on per-session STS user name)  
+  - ```OKTA_AWS_REGION``` is the default AWS region to store with the created profile.
   - ```OKTA_AWS_ROLE_TO_ASSUME``` is the role to use. If present will try to match okta account's retrieved role list and use it. Will still prompt if no match found.
   - ```OKTA_STS_DURATION``` is the duration the role will be assumed, in seconds. The maximum session duration allowed by AWS is 12 hours and this needs to be set on the role as well.  Defaults to 1hr.
   
@@ -145,6 +146,11 @@ at least allow the role to assume itself:
     ]
 }
 ```
+
+### Add config.properties parameters to support silent mode without prompt for user input (2018/6/22 update)
+- OKTA_AWS_REGION
+
+Same parameters can be set as environment variable. config.properties parameter has priority over environment variable.
 
 ### Add config.properties parameters to support silent mode without prompt for user input (2017/6/8 update)
 - OKTA_USERNAME

--- a/Readme.MD
+++ b/Readme.MD
@@ -102,7 +102,7 @@ Here is the list of parameters that must be maintained in the ```config.properti
   - ```OKTA_USERNAME``` is the username to use. If present will skip username input.
   - ```OKTA_PASSWORD``` is the password to use. If present will skip password input.
   - ```OKTA_BROWSER_AUTH``` set to **true** to use integrated web browser for authentication (default: **false**)
-  - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse (default: get AWS profile name based on per-session STS user name)  
+  - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse.  May also be specified on the commandline by ```--profile```. (default: get AWS profile name based on per-session STS user name)  
   - ```OKTA_AWS_REGION``` is the default AWS region to store with the created profile.
   - ```OKTA_AWS_ROLE_TO_ASSUME``` is the role to use. If present will try to match okta account's retrieved role list and use it. Will still prompt if no match found.
   - ```OKTA_STS_DURATION``` is the duration the role will be assumed, in seconds. The maximum session duration allowed by AWS is 12 hours and this needs to be set on the role as well.  Defaults to 1hr.
@@ -148,6 +148,7 @@ at least allow the role to assume itself:
 ```
 
 ### Add config.properties parameters to support silent mode without prompt for user input (2018/6/22 update)
+- Add commandline support for ```--profile``` to specify OKTA_PROFILE
 - OKTA_AWS_REGION
 
 Same parameters can be set as environment variable. config.properties parameter has priority over environment variable.

--- a/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
@@ -12,9 +12,12 @@ public class OktaAwsCliEnvironment {
     public String awsRoleToAssume;
 
     public int stsDuration;
+    public final String awsRegion;
 
-    public OktaAwsCliEnvironment(boolean browserAuth, String oktaOrg, String oktaUsername, String oktaPassword, String oktaProfile,
-                                 String oktaAwsAppUrl, String awsRoleToAssume, int stsDuration) {
+    public OktaAwsCliEnvironment(boolean browserAuth, String oktaOrg, 
+                                 String oktaUsername, String oktaPassword, String oktaProfile,
+                                 String oktaAwsAppUrl, String awsRoleToAssume, int stsDuration,
+                                 String awsRegion) {
         this.browserAuth = browserAuth;
         this.oktaOrg = oktaOrg;
         this.oktaUsername = oktaUsername;
@@ -23,5 +26,6 @@ public class OktaAwsCliEnvironment {
         this.oktaAwsAppUrl = oktaAwsAppUrl;
         this.awsRoleToAssume = awsRoleToAssume;
         this.stsDuration = stsDuration;
+        this.awsRegion = awsRegion;
     }
 }

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -15,6 +15,10 @@ final class OktaAwsConfig {
     private static final String CONFIG_FILENAME = "config.properties";
 
     static OktaAwsCliEnvironment loadEnvironment() {
+        return loadEnvironment(null);
+    }
+
+    static OktaAwsCliEnvironment loadEnvironment(String profile) {        
         Properties properties = new Properties();
         getConfigFile().ifPresent(configFile -> {
             try (InputStream config = new FileInputStream(configFile.toFile())) {
@@ -29,7 +33,7 @@ final class OktaAwsConfig {
                 getEnvOrConfig(properties, "OKTA_ORG"),
                 getEnvOrConfig(properties, "OKTA_USERNAME"),
                 getEnvOrConfig(properties, "OKTA_PASSWORD"),
-                getEnvOrConfig(properties, "OKTA_PROFILE"),
+                getProfile(profile, getEnvOrConfig(properties, "OKTA_PROFILE")),
                 getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),
                 getEnvOrConfig(properties, "OKTA_AWS_ROLE_TO_ASSUME"),
                 getStsDurationOrDefault(getEnvOrConfig(properties, "OKTA_STS_DURATION")),
@@ -55,6 +59,11 @@ final class OktaAwsConfig {
         String envValue = System.getenv(propertyName);
         return envValue != null ?
                 envValue : properties.getProperty(propertyName);
+    }
+
+    private static String getProfile(String profileFromCmdLine, String profileFromEnvOrConfig) {
+        return profileFromCmdLine != null ?
+                profileFromCmdLine : profileFromEnvOrConfig;
     }
 
     private static Integer getStsDurationOrDefault(String stsDuration) {

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -32,7 +32,8 @@ final class OktaAwsConfig {
                 getEnvOrConfig(properties, "OKTA_PROFILE"),
                 getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),
                 getEnvOrConfig(properties, "OKTA_AWS_ROLE_TO_ASSUME"),
-                getStsDurationOrDefault(getEnvOrConfig(properties, "OKTA_STS_DURATION"))
+                getStsDurationOrDefault(getEnvOrConfig(properties, "OKTA_STS_DURATION")),
+                getAwsRegionOrDefault(getEnvOrConfig(properties, "OKTA_AWS_REGION"))
         );
     }
 
@@ -58,5 +59,9 @@ final class OktaAwsConfig {
 
     private static Integer getStsDurationOrDefault(String stsDuration) {
         return (stsDuration == null) ? 3600 : Integer.parseInt(stsDuration);
+    }
+
+    private static String getAwsRegionOrDefault(String region) {
+        return (region == null) ? "us-east-1" : region;
     }
 }

--- a/src/main/java/com/okta/tools/aws/settings/Configuration.java
+++ b/src/main/java/com/okta/tools/aws/settings/Configuration.java
@@ -26,7 +26,6 @@ public class Configuration extends Settings {
     static final String SOURCE_PROFILE = "source_profile";
     static final String REGION = "region";
     static final String PROFILE_PREFIX = "profile ";
-    private static final String REGION_DEFAULT = "us-east-1";
 
     /**
      * Create a Configuration object from a given {@link Reader}. The data given by this {@link Reader} should
@@ -42,12 +41,13 @@ public class Configuration extends Settings {
     /**
      * Add or update a profile to an AWS config file based on {@code name}. This will be linked to a credential profile
      * of the same {@code name}, which should already be present in the credentials file.
-     * The region for this new profile will be {@link Configuration#REGION_DEFAULT}.
+     * The region for this new profile will be {@link OktaAwsCliEnvironment#awsRegion}.
      *
      * @param name         The name of the profile.
      * @param roleToAssume The ARN of the role to assume in this profile.
+     * @param region       The AWS to use if not already present in the profile.
      */
-    public void addOrUpdateProfile(String name, String roleToAssume) {
+    public void addOrUpdateProfile(String name, String roleToAssume, String region) {
         // profileName is the string used for the section in the AWS config file.
         // This should be prefixed with "profile ".
         final String profileName = PROFILE_PREFIX + name;
@@ -56,21 +56,21 @@ public class Configuration extends Settings {
         // profile to this profile.
         final boolean newConfig = settings.isEmpty();
         if (newConfig) {
-            writeConfigurationProfile(settings.add(DEFAULTPROFILENAME), name, roleToAssume);
+            writeConfigurationProfile(settings.add(DEFAULTPROFILENAME), name, roleToAssume, region);
         }
 
         // Write the new profile data
         final Profile.Section awsProfile = settings.get(profileName) != null
                 ? settings.get(profileName)
                 : settings.add(profileName);
-        writeConfigurationProfile(awsProfile, name, roleToAssume);
+        writeConfigurationProfile(awsProfile, name, roleToAssume, region);
     }
 
-    private void writeConfigurationProfile(Profile.Section awsProfile, String name, String roleToAssume) {
+    private void writeConfigurationProfile(Profile.Section awsProfile, String name, String roleToAssume, String region) {
         awsProfile.put(ROLE_ARN, roleToAssume);
         awsProfile.put(SOURCE_PROFILE, name + "_source");
         if (!awsProfile.containsKey(REGION)) {
-            awsProfile.put(REGION, REGION_DEFAULT);
+            awsProfile.put(REGION, region);
         }
     }
 }

--- a/src/main/java/com/okta/tools/awscli.java
+++ b/src/main/java/com/okta/tools/awscli.java
@@ -22,15 +22,28 @@ import java.util.List;
 
 public class awscli {
     public static void main(String[] args) throws Exception {
+        // support named profiles from the CLI
+        // https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html
+        String profile = null;
+        boolean hasProfile = false;
+        for (String arg : args) {
+            if (hasProfile) {
+                profile = arg;
+                break;
+            }
+            hasProfile = "--profile".equals(arg);
+        }
+
         if (args.length > 0 && "logout".equals(args[0])) {
-            OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).logoutSession();
+            OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment(profile)).logoutSession();
             System.out.println("You have been logged out");
             System.exit(0);
             return;
         }
 
+
         List<String> awsCommand = new ArrayList<>();
-        String profileName = OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).run(Instant.now());
+        String profileName = OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment(profile)).run(Instant.now());
         awsCommand.add("aws");
         awsCommand.add("--profile");
         awsCommand.add(profileName);

--- a/src/main/java/com/okta/tools/helpers/ConfigHelper.java
+++ b/src/main/java/com/okta/tools/helpers/ConfigHelper.java
@@ -46,7 +46,7 @@ public final class ConfigHelper {
             Configuration configuration = new Configuration(reader);
 
             // Write the given profile data
-            configuration.addOrUpdateProfile(environment.oktaProfile, environment.awsRoleToAssume);
+            configuration.addOrUpdateProfile(environment.oktaProfile, environment.awsRoleToAssume, environment.awsRegion);
 
             // Write the updated profile
             try (FileWriter fileWriter = getConfigWriter()) {

--- a/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
@@ -71,7 +71,7 @@ class ConfigurationTest {
         assertTrue(initiallyEmpty.settings.isEmpty());
 
         // Write an initial profile. This should create a default profile as well.
-        initiallyEmpty.addOrUpdateProfile(profileName, role_arn);
+        initiallyEmpty.addOrUpdateProfile(profileName, role_arn, region);
         assertEquals(2, initiallyEmpty.settings.size());
         assertEquals(profileName + "_source", initiallyEmpty.settings.get(DEFAULTPROFILENAME, SOURCE_PROFILE));
         assertEquals(role_arn, initiallyEmpty.settings.get(DEFAULTPROFILENAME, ROLE_ARN));
@@ -80,7 +80,7 @@ class ConfigurationTest {
 
         // Write another profile. Make sure the default profile is left alone.
         final String postfix = "_2";
-        initiallyEmpty.addOrUpdateProfile(profileName + postfix, role_arn + postfix);
+        initiallyEmpty.addOrUpdateProfile(profileName + postfix, role_arn + postfix, region);
         assertTrue(initiallyEmpty.settings.containsKey(PROFILE_PREFIX + profileName + postfix));
         assertEquals(3, initiallyEmpty.settings.size());
         assertEquals(defaultProfileBefore, sectionToMap.apply(initiallyEmpty.settings.get(DEFAULTPROFILENAME)));
@@ -95,7 +95,7 @@ class ConfigurationTest {
         final StringWriter configurationWriter = new StringWriter();
         final Configuration configuration = new Configuration(configurationReader);
 
-        configuration.addOrUpdateProfile(profileName, role_arn);
+        configuration.addOrUpdateProfile(profileName, role_arn, region);
         configuration.save(configurationWriter);
 
         String expected = existingProfile + "\n\n" + manualRole;
@@ -121,7 +121,7 @@ class ConfigurationTest {
                 + "\n\n" + existingProfile;
 
 
-        configuration.addOrUpdateProfile(profileName, updatedPrefix + role_arn);
+        configuration.addOrUpdateProfile(profileName, updatedPrefix + role_arn, region);
         configuration.save(configurationWriter);
 
         String given = StringUtils.remove(configurationWriter.toString().trim(), '\r');


### PR DESCRIPTION
Problem Statement
-----------------
Currently AWSCLI profiles always default to us-east-1, one of many AWS regions. It is not possible to change this with the current published jar.

For organizations with many AWS accounts, there is often a need to access multiple profiles on a daily basis. Currently this requires modifying OKTA_PROFILE in the environment or config.properties files to create a friendly profile name.


Solution
--------
Allow default region to be specified via OKTA_AWS_REGION

Allow OKTA_PROFILE to be specified on the awscli commandline via the --profile option.

upstream pull request - https://github.com/oktadeveloper/okta-aws-cli-assume-role/pull/131